### PR TITLE
Special Case permitting single row to referenced in Range()

### DIFF
--- a/xltable/__init__.py
+++ b/xltable/__init__.py
@@ -101,6 +101,8 @@ Classes
 
 .. autoclass:: ArrayExpression
 
+.. autoclass:: ArrayConstant
+
 .. autoclass:: Cell
 
 .. autoclass:: Column
@@ -118,7 +120,7 @@ Classes
 .. autoclass:: Value
 
 """
-from .expression import Column, Index, Cell, Range, Formula, ConstExpr, Expression, ArrayExpression
+from .expression import Column, Index, Cell, Range, Formula, ConstExpr, Expression, ArrayExpression, ArrayConstant
 from .style import CellStyle, TableStyle
 from .table import Table, Value, ArrayFormula
 from .chart import Chart
@@ -143,4 +145,5 @@ __all__ = [
     "Formula",
     "ArrayExpression",
     "ConstExpr",
+    "ArrayConstant"
 ]

--- a/xltable/expression.py
+++ b/xltable/expression.py
@@ -357,6 +357,21 @@ class ConstExpr(Expression):
         return str(self.__value)
 
 
+class ArrayConstant(Expression):
+    """
+    An evaluated array, an "Array Constant". Can increase performance and/or
+    reduce dependencies
+    """
+    def __init__(self, array, **kwargs):
+        super(ArrayConstant, self).__init__(**kwargs)
+        self.value = array
+        self.__value = array
+
+    def resolve(self, workbook, row, col):
+        arr_str = ";".join(",".join(map(str,row)) for row in self.__value)
+        return "{%s}" % arr_str
+
+
 def _to_addr(worksheet, row, col, row_fixed=False, col_fixed=False):
     """converts a (0,0) based coordinate to an excel address"""
     addr = ""

--- a/xltable/expression.py
+++ b/xltable/expression.py
@@ -207,7 +207,7 @@ class Range(Expression):
     :param left_col: Left most column label this refers to.
     :param right_col: Right most column label this refers to.
     :param top_row: Top most row label, or None to select from the top of the table.
-    :param bottom_row: Bottom most row label, or None to select to the bottom of the table.
+    :param bottom_row: Bottom most row label, or None to select to the bottom of the table, or False to select single row
     :param include_header: Include table header in the range.
     :param table: Name of table the column is in, if not in the same table this expression is in.
                   Use "%s!%s" % (worksheet.name, table.name) if refering to a table in another worksheet
@@ -247,6 +247,8 @@ class Range(Expression):
 
         if self.__bottom is None:
             bottom_row_offset = table.height - 1
+        elif self.__bottom is False:
+            bottom_row_offset = top_row_offset
         else:
             bottom_row_offset = table.get_row_offset(self.__bottom)
 


### PR DESCRIPTION
A special case where only the header row needs to be referenced appears difficult to implement. Referencing the table header row is useful in e.g. Index(Match()) type formulae. 

Suggest a special case where bottom_row=False (rather than None or a index item key being provided) in which the bottom_row_offset is set to the top_row_offset so as to reference the single header row.